### PR TITLE
use starstwith instead of lstrip for substring

### DIFF
--- a/koalified/_version.py
+++ b/koalified/_version.py
@@ -1,2 +1,2 @@
 """Stores the current version for easy use across the code-base"""
-current = "0.0.2"
+current = "0.0.3"

--- a/koalified/schema.py
+++ b/koalified/schema.py
@@ -1,5 +1,4 @@
 import yaml
-import json
 import xxhash
 import requests
 from koalified import types
@@ -51,7 +50,8 @@ class Schema(object):
             if uri.startswith('http'):
                 text = requests.get(uri).content
             else:
-                with open(uri.lstrip('file://')) as schema_file:
+                uri = uri[len('file://'):] if uri.startswith('file://') else uri
+                with open(uri) as schema_file:
                     text = schema_file.read()
 
         definition = yaml.safe_load(text)

--- a/setup.py
+++ b/setup.py
@@ -2,11 +2,10 @@
 """Defines the setup instructions for koalified"""
 import glob
 import os
-import subprocess
 import sys
 from os import path
 
-from setuptools import Extension, find_packages, setup
+from setuptools import Extension, setup
 from setuptools.command.test import test as TestCommand
 
 MYDIR = path.abspath(os.path.dirname(__file__))
@@ -56,13 +55,13 @@ class PyTest(TestCommand):
 cmdclass['test'] = PyTest
 
 try:
-   import pypandoc
-   readme = pypandoc.convert('README.md', 'rst')
+    import pypandoc
+    readme = pypandoc.convert('README.md', 'rst')
 except (IOError, ImportError, OSError, RuntimeError):
-   readme = ''
+    readme = ''
 
 setup(name='koalified',
-      version='0.0.2',
+      version='0.0.3',
       description='For when truth is a little fuzzy.',
       long_description=readme,
       author='DomainTools',
@@ -70,10 +69,10 @@ setup(name='koalified',
       url='https://github.com/domaintools/koalified_python',
       license="MIT",
       # entry_points={
-      #  'console_scripts': [
+      #   'console_scripts': [
       #      'koalified = koalified:run.terminal',
-      #  ]
-      #},
+      #   ]
+      # },
       packages=['koalified'],
       requires=[],
       install_requires=['PyYAML', 'validators', 'requests', 'xxhash', 'phonenumbers', 'pycountry', 'arrow'],

--- a/tests/test_schema.py
+++ b/tests/test_schema.py
@@ -1,3 +1,4 @@
+import os
 import pytest
 
 from koalified.schema import Schema
@@ -25,6 +26,10 @@ def test_load_schema():
     schema = Schema(uri='https://raw.github.com/domaintools/koalified_python/develop/examples/example_schema.yaml')
     schema = Schema(text=EXAMPLE_SCHEMA, fail_fast=False, score_fields=True, explain=True, precompile=True)
     schema = Schema(uri='./examples/example_schema2.yaml')
+
+    abspath = os.path.abspath(os.path.dirname(__file__))
+    schema = Schema(uri=abspath + '/../examples/example_schema2.yaml')
+
     schema = Schema(text=EXAMPLE_SCHEMA)
     schema.compiled()
     assert schema({'contact': [{'phone': '410'}]})


### PR DESCRIPTION
The 0.0.2 code used lstrip inappropriately.  A test using abspath shows
that it was stripping the leading slash.

Some small linting.
Provides a bug version bump for easy deploy.