### PR TITLE
fix invocation of Cython.inline

### DIFF
--- a/koalified/compile.py
+++ b/koalified/compile.py
@@ -20,7 +20,7 @@ def to_python(schema):
     if Cython and hasattr(Cython, "inline"):
         name_space = schema.supported_types.copy()
         name_space["metadata"] = schema.metadata
-        name_space = Cython.inline(code, name_space)
+        name_space = Cython.inline(code, globals=name_space)
     else:
         name_space = schema.supported_types.copy()
         name_space["metadata"] = schema.metadata

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,10 @@
 [tox]
 envlist=py36
+        py36-cython
+
+[testenv:py36-cython]
+deps=-rrequirements/development.txt
+     Cython
 
 [testenv]
 deps=-rrequirements/development.txt


### PR DESCRIPTION
Cython.inline takes globals and locals as kwargs.  This adds a cython
enabled environment to the tox setup, so both branches of
koalified/compile:to_python are tested.